### PR TITLE
fix: #71 library ctx menu item no longer disappears with app overview changes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,6 @@ import {
   definePlugin,
   ServerAPI,
   quickAccessMenuClasses,
-  Patch,
   findSP,
 } from 'decky-frontend-lib';
 
@@ -30,7 +29,7 @@ export default definePlugin((serverApi: ServerAPI) => {
     exact: true,
   });
 
-  const patchedMenu: Patch = contextMenuPatch(LibraryContextMenu);
+  const menuPatches = contextMenuPatch(LibraryContextMenu);
 
   getSetting('squares', false).then((enabled) => {
     console.log('enabled on load:', enabled);
@@ -46,7 +45,7 @@ export default definePlugin((serverApi: ServerAPI) => {
     icon: <MenuIcon />,
     onDismount() {
       serverApi.routerHook.removeRoute('/steamgriddb/:appid/:assetType?');
-      patchedMenu?.unpatch();
+      menuPatches?.unpatch();
 
       removeSquareLibraryPatch(serverApi, true);
       removeSquareHomePatch(serverApi, true);


### PR DESCRIPTION
You guys were close with this. Instead of checking if a certain app has rendered the menu and single shot patch ```shouldComponentUpdate```, we just need to apply the patch once but leave it patched. It applies to all apps that render the menu. I tested this alongside "Game Theme Music" plugin which I think uses the same patching method you guys had, and in all my testing the 'change artwork' item never disappeared, while Game Theme's icon would disappear.