### PR TITLE
Feature: Always show labels with game names below the capsules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decky-steamgriddb",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Decky plugin to manage Steam artwork from within gaming mode.",
   "type": "module",
   "scripts": {

--- a/src/components/qam-contents/QuickAccessSettings.tsx
+++ b/src/components/qam-contents/QuickAccessSettings.tsx
@@ -46,20 +46,22 @@ const squareGridSizes = DIMENSIONS.grid_p.options.filter((x) => {
 }).map((x) => x.value);
 
 // Set square/uniform featured game using logic written at 3am
-const setPatches = (squares: boolean, uniformFeatured: boolean): void => {
-  if (!uniformFeatured && !squares) {
-    removeHomePatch();
-  } else if (squares || uniformFeatured) {
-    // Remove the home patch then patch it again
-    removeHomePatch();
-    addHomePatch(false, squares, uniformFeatured);
-    if (squares) {
-      addSquareLibraryPatch();
-    }
-  }
-  if (!squares) {
+const setPatches = (
+  squares: boolean,
+  uniformFeatured: boolean,
+  gamelabel: boolean = false,
+): void => {
+  if (squares) {
+    addSquareLibraryPatch();
+  } else {
     removeSquareLibraryPatch();
   }
+
+  removeHomePatch();
+  if (uniformFeatured) addHomePatch(false, squares, uniformFeatured);
+
+  removeGameLabelsStyle();
+  if (gamelabel) addGameLabelsStyle(squares);
 };
 
 const QuickAccessSettings: VFC = () => {
@@ -72,25 +74,25 @@ const QuickAccessSettings: VFC = () => {
   const [capsuleGlowAmount, setCapsuleGlowAmount] = useState(100);
   const [debugAppid] = useState('70');
 
-  const handleGameLabelsToggle = useCallback(async (checked: boolean) => {
-    set('show_game_labels', checked, true);
-    setShowGameLabels(checked);
-    if (checked) {
-      addGameLabelsStyle();
-    } else {
-      removeGameLabelsStyle();
-    }
-  }, [set]);
+  const handleGameLabelsToggle = useCallback(
+    async (checked: boolean) => {
+      set("show_game_labels", checked, true);
+      setShowGameLabels(checked);
+      setPatches(squares, uniformFeatured, showGameLabels);
+    },
+    [set],
+  );
 
   const handleMotdToggle = useCallback(async (val: boolean) => {
     set('motd_hidden_global', val, true);
     setMotdToggle(val);
   }, [set]);
 
-  const handleSquareToggle = useCallback(async (checked: boolean) => {
-    set('squares', checked, true);
-    setSquares(checked);
-    setPatches(checked, uniformFeatured);
+  const handleSquareToggle = useCallback(
+    async (checked: boolean) => {
+      set("squares", checked, true);
+      setSquares(checked);
+      setPatches(squares, uniformFeatured, showGameLabels);
 
     const currentFilters = await get('filters_grid_p', {});
     if (checked) {
@@ -103,11 +105,14 @@ const QuickAccessSettings: VFC = () => {
     set('filters_grid_p', currentFilters, true);
   }, [get, set, uniformFeatured]);
 
-  const handleUniformFeaturedToggle = useCallback(async (checked: boolean) => {
-    set('uniform_featured', checked, true);
-    setUniformFeatured(checked);
-    setPatches(squares, checked);
-  }, [set, squares]);
+  const handleUniformFeaturedToggle = useCallback(
+    async (checked: boolean) => {
+      set("uniform_featured", checked, true);
+      setUniformFeatured(checked);
+      setPatches(squares, uniformFeatured, showGameLabels);
+    },
+    [set, squares],
+  );
 
   const handleCapsuleGlowChange = useCallback(async (val: number) => {
     set('capsule_glow_amount', val, true);

--- a/src/components/qam-contents/QuickAccessSettings.tsx
+++ b/src/components/qam-contents/QuickAccessSettings.tsx
@@ -32,6 +32,7 @@ import useSettings, { SettingsProvider } from '../../hooks/useSettings';
 import { addHomePatch, removeHomePatch } from '../../patches/homePatch';
 import { addSquareLibraryPatch, removeSquareLibraryPatch } from '../../patches/squareLibraryPatch';
 import { addCapsuleGlowPatch } from '../../patches/capsuleGlowPatch';
+import { addGameLabelsStyle, removeGameLabelsStyle } from '../../patches/gameLabelsStyle';
 import { DIMENSIONS } from '../../constants';
 import { appgridClasses } from '../../static-classes';
 
@@ -66,9 +67,20 @@ const QuickAccessSettings: VFC = () => {
   const [useCount, setUseCount] = useState<number | null>(null);
   const [squares, setSquares] = useState<boolean>(false);
   const [uniformFeatured, setUniformFeatured] = useState<boolean>(false);
+  const [showGameLabels, setShowGameLabels] = useState<boolean>(false);
   const [motdToggle, setMotdToggle] = useState<boolean>(false);
   const [capsuleGlowAmount, setCapsuleGlowAmount] = useState(100);
   const [debugAppid] = useState('70');
+
+  const handleGameLabelsToggle = useCallback(async (checked: boolean) => {
+    set('show_game_labels', checked, true);
+    setShowGameLabels(checked);
+    if (checked) {
+      addGameLabelsStyle();
+    } else {
+      removeGameLabelsStyle();
+    }
+  }, [set]);
 
   const handleMotdToggle = useCallback(async (val: boolean) => {
     set('motd_hidden_global', val, true);
@@ -113,6 +125,9 @@ const QuickAccessSettings: VFC = () => {
       setUseCount(await get('plugin_use_count', 0));
       setSquares(await get('squares', false));
       setUniformFeatured(await get('uniform_featured', false));
+      const labelsEnabled = await get('show_game_labels', false);
+      setShowGameLabels(labelsEnabled);
+      if (labelsEnabled) addGameLabelsStyle();
       setCapsuleGlowAmount(await get('capsule_glow_amount', 100));
       setMotdToggle(await get('motd_hidden_global', false));
     })();
@@ -219,6 +234,14 @@ const QuickAccessSettings: VFC = () => {
             description={t('LABEL_UNIFORM_RECENT_DESC', 'Make the most recently played game on the home screen match the rest of the capsules.')}
             checked={uniformFeatured}
             onChange={handleUniformFeaturedToggle}
+          />
+        </PanelSectionRow>
+        <PanelSectionRow>
+          <ToggleField
+            label={t('LABEL_SHOW_GAME_LABELS', 'Always Show Game Labels')}
+            description={t('LABEL_SHOW_GAME_LABELS_DESC', 'Always display game names below their capsules in the library.')}
+            checked={showGameLabels}
+            onChange={handleGameLabelsToggle}
           />
         </PanelSectionRow>
         {appgridClasses?.LibraryImageBackgroundGlow && (

--- a/src/components/qam-contents/QuickAccessSettings.tsx
+++ b/src/components/qam-contents/QuickAccessSettings.tsx
@@ -58,7 +58,7 @@ const setPatches = (squares: boolean, uniformFeatured: boolean): void => {
   }
 
   removeGameLabelSizeStyle();
-  addGameLabelSizeStyle(squares);
+  addGameLabelSizeStyle(false, squares);
 };
 
 const QuickAccessSettings: VFC = () => {

--- a/src/components/qam-contents/QuickAccessSettings.tsx
+++ b/src/components/qam-contents/QuickAccessSettings.tsx
@@ -32,7 +32,7 @@ import useSettings, { SettingsProvider } from '../../hooks/useSettings';
 import { addHomePatch, removeHomePatch } from '../../patches/homePatch';
 import { addSquareLibraryPatch, removeSquareLibraryPatch } from '../../patches/squareLibraryPatch';
 import { addCapsuleGlowPatch } from '../../patches/capsuleGlowPatch';
-import { addGameLabelsStyle, removeGameLabelsStyle } from '../../patches/gameLabelsStyle';
+import { addGameLabelsStyle, removeGameLabelsStyle, addGameLabelSizeStyle, removeGameLabelSizeStyle } from '../../patches/gameLabelsStyle';
 import { DIMENSIONS } from '../../constants';
 import { appgridClasses } from '../../static-classes';
 
@@ -45,23 +45,49 @@ const squareGridSizes = DIMENSIONS.grid_p.options.filter((x) => {
   return w === h;
 }).map((x) => x.value);
 
-// Set square/uniform featured game using logic written at 3am
-const setPatches = (
-  squares: boolean,
-  uniformFeatured: boolean,
-  gamelabel: boolean = false,
-): void => {
+const setPatches = (squares: boolean, uniformFeatured: boolean): void => {
+  // needs to be rerendered in any case depending on parameters
+  removeHomePatch();
+
+  if (squares || uniformFeatured) addHomePatch(false, squares, uniformFeatured);
+
   if (squares) {
-    addSquareLibraryPatch();
+    addSquareLibraryPatch(false);
   } else {
     removeSquareLibraryPatch();
   }
 
-  removeHomePatch();
-  if (uniformFeatured) addHomePatch(false, squares, uniformFeatured);
+  removeGameLabelSizeStyle();
+  addGameLabelSizeStyle(squares);
 
-  removeGameLabelsStyle();
-  if (gamelabel) addGameLabelsStyle(squares);
+  // if (!uniformFeatured && !squares) {
+  //   removeHomePatch();
+  // } else if (squares || uniformFeatured) {
+  //   // Remove the home patch then patch it again
+  //   removeHomePatch();
+  //   addHomePatch(false, squares, uniformFeatured);
+  // }
+
+  // if (squares) {
+  //   addSquareLibraryPatch();
+  // }
+  // else {
+  //   removeSquareLibraryPatch();
+  // }
+
+  // if (squares) {
+  //   addSquareLibraryPatch(false);
+  // } else {
+  //   removeSquareLibraryPatch();
+  // }
+
+  // // needs to be rerendered in any case depending on parameters
+  // removeHomePatch();
+  // if (squares || uniformFeatured) addHomePatch(false, squares, uniformFeatured);
+
+  // // needs to be rerendered in any case depending on parameters
+  // removeGameLabelsStyle();
+  // if (gamelabel) addGameLabelsStyle(false, squares);
 };
 
 const QuickAccessSettings: VFC = () => {
@@ -78,7 +104,11 @@ const QuickAccessSettings: VFC = () => {
     async (checked: boolean) => {
       set("show_game_labels", checked, true);
       setShowGameLabels(checked);
-      setPatches(squares, uniformFeatured, showGameLabels);
+
+      if (checked)
+        addGameLabelsStyle(false);
+      else
+        removeGameLabelsStyle();
     },
     [set],
   );
@@ -92,7 +122,7 @@ const QuickAccessSettings: VFC = () => {
     async (checked: boolean) => {
       set("squares", checked, true);
       setSquares(checked);
-      setPatches(squares, uniformFeatured, showGameLabels);
+      setPatches(checked, uniformFeatured);
 
     const currentFilters = await get('filters_grid_p', {});
     if (checked) {
@@ -109,7 +139,7 @@ const QuickAccessSettings: VFC = () => {
     async (checked: boolean) => {
       set("uniform_featured", checked, true);
       setUniformFeatured(checked);
-      setPatches(squares, uniformFeatured, showGameLabels);
+      setPatches(squares, checked);
     },
     [set, squares],
   );

--- a/src/components/qam-contents/QuickAccessSettings.tsx
+++ b/src/components/qam-contents/QuickAccessSettings.tsx
@@ -59,35 +59,6 @@ const setPatches = (squares: boolean, uniformFeatured: boolean): void => {
 
   removeGameLabelSizeStyle();
   addGameLabelSizeStyle(squares);
-
-  // if (!uniformFeatured && !squares) {
-  //   removeHomePatch();
-  // } else if (squares || uniformFeatured) {
-  //   // Remove the home patch then patch it again
-  //   removeHomePatch();
-  //   addHomePatch(false, squares, uniformFeatured);
-  // }
-
-  // if (squares) {
-  //   addSquareLibraryPatch();
-  // }
-  // else {
-  //   removeSquareLibraryPatch();
-  // }
-
-  // if (squares) {
-  //   addSquareLibraryPatch(false);
-  // } else {
-  //   removeSquareLibraryPatch();
-  // }
-
-  // // needs to be rerendered in any case depending on parameters
-  // removeHomePatch();
-  // if (squares || uniformFeatured) addHomePatch(false, squares, uniformFeatured);
-
-  // // needs to be rerendered in any case depending on parameters
-  // removeGameLabelsStyle();
-  // if (gamelabel) addGameLabelsStyle(false, squares);
 };
 
 const QuickAccessSettings: VFC = () => {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -19,6 +19,8 @@
   "LABEL_SQUARE_CAPSULES_DESC": "Benutze quadratische Kapseln anstelle von Kapseln im Hochformat. Quadratische Filter werden automatisch ausgewählt.",
   "LABEL_UNIFORM_RECENT": "Passende Zuletzt-Gespielt Kapsel",
   "LABEL_UNIFORM_RECENT_DESC": "Passt die Kapsel des zuletzt gespielten Spieles an das Aussehen der regulären Kapseln an.",
+  "LABEL_SHOW_GAME_LABELS": "Zeige Spielenamen immer",
+  "LABEL_SHOW_GAME_LABELS_DESC": "Zeige den Spielenamen immer unter der Kapsel.",
   "LABEL_CAPSULE_GLOW": "Kapsel-Glühen",
   "LABEL_CAPSULE_GLOW_DESC": "Passe die Intensität des Glühens der Kapseln in der Bibliothek an.",
   "LABEL_CAPSULE_GLOW_OFF": "Keine Auswahl",

--- a/src/i18n/strings.json
+++ b/src/i18n/strings.json
@@ -19,6 +19,8 @@
   "LABEL_SQUARE_CAPSULES_DESC": "Use square capsules instead of portrait ones. Square filters will be automatically selected.",
   "LABEL_UNIFORM_RECENT": "Matching Recents Capsule",
   "LABEL_UNIFORM_RECENT_DESC": "Make the most recently played game on the home screen match the rest of the capsules.",
+  "LABEL_SHOW_GAME_LABELS": "Always Show Game Labels",
+  "LABEL_SHOW_GAME_LABELS_DESC": "Always display game names below their capsules in the library.",
   "LABEL_CAPSULE_GLOW": "Capsule Glow",
   "LABEL_CAPSULE_GLOW_DESC": "Adjust capsule glow intensity in the library.",
   "LABEL_CAPSULE_GLOW_OFF": "None",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import contextMenuPatch, { LibraryContextMenu } from './patches/contextMenuPatch
 import { removeSquareLibraryPatch, addSquareLibraryPatch } from './patches/squareLibraryPatch';
 import { removeHomePatch, addHomePatch } from './patches/homePatch';
 import { addCapsuleGlowPatch } from './patches/capsuleGlowPatch';
-import { addGameLabelsStyle } from './patches/gameLabelsStyle';
+import { addGameLabelsStyle, removeGameLabelsStyle, addGameLabelSizeStyle, removeGameLabelSizeStyle, STYLE_GAME_LABEL, STYLE_GAME_LABEL_SIZE } from './patches/gameLabelsStyle';
 import { removeStyles } from './utils/styleInjector';
 
 export default definePlugin(() => {
@@ -40,14 +40,16 @@ export default definePlugin(() => {
       }
       addHomePatch(true, squares, uniformFeatured);
     }
+
+    addGameLabelSizeStyle(squares);
   });
 
   getSetting('capsule_glow_amount', 100).then((amount) => {
     addCapsuleGlowPatch(parseInt(amount, 10));
   });
 
-  getSetting('show_game_labels', false).then((enabled) => {
-    if (enabled) addGameLabelsStyle();
+  getSetting('show_game_labels', false).then((showGameLabels) => {
+    if (showGameLabels) addGameLabelsStyle(true);
   });
 
   return {
@@ -60,13 +62,16 @@ export default definePlugin(() => {
 
       removeSquareLibraryPatch(true);
       removeHomePatch(true);
+      removeGameLabelsStyle(true);
+      removeGameLabelSizeStyle(true);
 
       removeStyles(
         'sgdb-square-capsules-library',
         'sgdb-square-capsules-home',
         'sgdb-capsule-glow',
         'sgdb-carousel-logo',
-        'sgdb-always-show-game-labels'
+        STYLE_GAME_LABEL,
+        STYLE_GAME_LABEL_SIZE
       );
     },
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ export default definePlugin(() => {
       addHomePatch(true, squares, uniformFeatured);
     }
 
-    addGameLabelSizeStyle(squares);
+    addGameLabelSizeStyle(true, squares);
   });
 
   getSetting('capsule_glow_amount', 100).then((amount) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import contextMenuPatch, { LibraryContextMenu } from './patches/contextMenuPatch
 import { removeSquareLibraryPatch, addSquareLibraryPatch } from './patches/squareLibraryPatch';
 import { removeHomePatch, addHomePatch } from './patches/homePatch';
 import { addCapsuleGlowPatch } from './patches/capsuleGlowPatch';
+import { addGameLabelsStyle } from './patches/gameLabelsStyle';
 import { removeStyles } from './utils/styleInjector';
 
 export default definePlugin(() => {
@@ -45,6 +46,10 @@ export default definePlugin(() => {
     addCapsuleGlowPatch(parseInt(amount, 10));
   });
 
+  getSetting('show_game_labels', false).then((enabled) => {
+    if (enabled) addGameLabelsStyle();
+  });
+
   return {
     title: <div className={quickAccessMenuClasses.Title}>SteamGridDB</div>,
     content: <SettingsProvider><QuickAccessSettings /></SettingsProvider>,
@@ -60,7 +65,8 @@ export default definePlugin(() => {
         'sgdb-square-capsules-library',
         'sgdb-square-capsules-home',
         'sgdb-capsule-glow',
-        'sgdb-carousel-logo'
+        'sgdb-carousel-logo',
+        'sgdb-always-show-game-labels'
       );
     },
   };

--- a/src/patches/gameLabelsStyle.ts
+++ b/src/patches/gameLabelsStyle.ts
@@ -1,18 +1,26 @@
-import { appportraitClasses, gamepadLibraryClasses } from '../static-classes';
-import { addStyle, removeStyle } from '../utils/styleInjector';
+import { findSP } from "@decky/ui";
 
-const STYLE_ID = 'sgdb-always-show-game-labels';
+import { addStyle } from "../utils/styleInjector";
 
-export const addGameLabelsStyle = () => {
-  addStyle(STYLE_ID, `
-    .${gamepadLibraryClasses.GamepadLibrary} .${appportraitClasses.AppPortraitBanner} {
-      opacity: 1 !important;
-      visibility: visible !important;
+const STYLE_ID = "sgdb-always-show-game-labels";
+
+export const addGameLabelsStyle = (_mounting = false) => {
+  addStyle(
+    STYLE_ID,
+    `
+    [role="gridcell"] div[id][style*="display"] {
       display: block !important;
+      text-align: center;
+      margin-top: 4px;
+      font-size: 0.7em;
+      white-space: normal;
+      overflow: visible;
+      word-wrap: break-word;
     }
-  `);
+  `,
+  );
 };
 
-export const removeGameLabelsStyle = () => {
-  removeStyle(STYLE_ID);
+export const removeGameLabelsStyle = (_unmounting = false) => {
+  findSP()?.window?.document?.getElementById(STYLE_ID)?.remove();
 };

--- a/src/patches/gameLabelsStyle.ts
+++ b/src/patches/gameLabelsStyle.ts
@@ -1,0 +1,18 @@
+import { appportraitClasses, gamepadLibraryClasses } from '../static-classes';
+import { addStyle, removeStyle } from '../utils/styleInjector';
+
+const STYLE_ID = 'sgdb-always-show-game-labels';
+
+export const addGameLabelsStyle = () => {
+  addStyle(STYLE_ID, `
+    .${gamepadLibraryClasses.GamepadLibrary} .${appportraitClasses.AppPortraitBanner} {
+      opacity: 1 !important;
+      visibility: visible !important;
+      display: block !important;
+    }
+  `);
+};
+
+export const removeGameLabelsStyle = () => {
+  removeStyle(STYLE_ID);
+};

--- a/src/patches/gameLabelsStyle.ts
+++ b/src/patches/gameLabelsStyle.ts
@@ -1,5 +1,6 @@
 import { findSP } from "@decky/ui";
 
+import { appportraitClasses } from "../static-classes";
 import { addStyle } from "../utils/styleInjector";
 
 const STYLE_ID = "sgdb-always-show-game-labels";
@@ -8,7 +9,7 @@ export const addGameLabelsStyle = (_mounting = false) => {
   addStyle(
     STYLE_ID,
     `
-    [role="gridcell"] div[id][style*="display"] {
+    .${appportraitClasses.LibraryItemBox} + div[id] {
       display: block !important;
       text-align: center;
       margin-top: 4px;

--- a/src/patches/gameLabelsStyle.tsx
+++ b/src/patches/gameLabelsStyle.tsx
@@ -5,7 +5,10 @@ import { addStyle } from "../utils/styleInjector";
 
 const STYLE_ID = "sgdb-always-show-game-labels";
 
-export const addGameLabelsStyle = (_mounting = false) => {
+export const addGameLabelsStyle = (
+  _mounting = false,
+  square: boolean = false,
+) => {
   addStyle(
     STYLE_ID,
     `

--- a/src/patches/gameLabelsStyle.tsx
+++ b/src/patches/gameLabelsStyle.tsx
@@ -15,12 +15,12 @@ export const addGameLabelsStyle = (
   // It has only an id like "<<rex>>" and an inline style "display: none".
   // Overwrite the inline style with !important.
   //
-  // TODO: Add .${gamepadLibraryClasses.GamepadLibrary} if different style for library and recently played
+  // In the home menu, the currently hovered over (mouse) or focused (gamepad selection) game will show its title anyways.
+  // So we need to differentiate and disable the label in that case.
   addStyle(
     STYLE_GAME_LABEL,
     `
-    .${gamepadLibraryClasses.GamepadLibrary} .${appportraitClasses.LibraryItemBox} + div[id] {
-      display: block !important;
+    .${appportraitClasses.LibraryItemBox}.Panel + div[id] {
       text-align: center;
       margin-top: 4px;
       margin-bottom: 4px;
@@ -28,14 +28,11 @@ export const addGameLabelsStyle = (
       overflow: visible;
       word-wrap: break-word;
     }
-    .${appportraitClasses.LibraryItemBox}.Panel:not(:hover,:focus) + div[id] {
+    .${gamepadLibraryClasses.GamepadLibrary} .${appportraitClasses.LibraryItemBox}.Panel + div[id] {
       display: block !important;
-      text-align: center;
-      margin-top: 4px;
-      margin-bottom: 4px;
-      white-space: normal;
-      overflow: visible;
-      word-wrap: break-word;
+    }
+    .${appportraitClasses.InRecentGames}.${appportraitClasses.LibraryItemBox}.Panel:not(:hover,:focus) + div[id] {
+      display: block !important;
     }
   `,
   );

--- a/src/patches/gameLabelsStyle.tsx
+++ b/src/patches/gameLabelsStyle.tsx
@@ -1,22 +1,29 @@
 import { findSP } from "@decky/ui";
 
-import { appportraitClasses } from "../static-classes";
+import { appportraitClasses, gamepadLibraryClasses } from "../static-classes";
 import { addStyle } from "../utils/styleInjector";
 
-const STYLE_ID = "sgdb-always-show-game-labels";
+export const STYLE_GAME_LABEL = "sgdb-always-show-game-labels";
+export const STYLE_GAME_LABEL_SIZE= "sgdb-always-show-game-labels-size"
+
+
 
 export const addGameLabelsStyle = (
-  _mounting = false,
-  square: boolean = false,
+  _mounting = false
 ) => {
+  // The game name label has no associated classes.
+  // It has only an id like "<<rex>>" and an inline style "display: none".
+  // Overwrite the inline style with !important.
+  //
+  // TODO: Add .${gamepadLibraryClasses.GamepadLibrary} if different style for library and recently played
   addStyle(
-    STYLE_ID,
+    STYLE_GAME_LABEL,
     `
     .${appportraitClasses.LibraryItemBox} + div[id] {
       display: block !important;
       text-align: center;
       margin-top: 4px;
-      font-size: 0.7em;
+      margin-bottom: 4px;
       white-space: normal;
       overflow: visible;
       word-wrap: break-word;
@@ -25,6 +32,26 @@ export const addGameLabelsStyle = (
   );
 };
 
+export const addGameLabelSizeStyle = (
+  _mounting = false,
+  square: boolean = false,
+) => {
+  let font_size = '0.7em';
+  if (square)
+    font_size = '0.8em';
+
+  addStyle(
+    STYLE_GAME_LABEL_SIZE,
+    `
+    .${appportraitClasses.LibraryItemBox} + div[id]
+    font-size: ${font_size};
+    `,);
+};
+
 export const removeGameLabelsStyle = (_unmounting = false) => {
-  findSP()?.window?.document?.getElementById(STYLE_ID)?.remove();
+  findSP()?.window?.document?.getElementById(STYLE_GAME_LABEL)?.remove();
+};
+
+export const removeGameLabelSizeStyle = (_unmounting = false) => {
+  findSP()?.window?.document?.getElementById(STYLE_GAME_LABEL_SIZE)?.remove();
 };

--- a/src/patches/gameLabelsStyle.tsx
+++ b/src/patches/gameLabelsStyle.tsx
@@ -43,17 +43,22 @@ export const addGameLabelsStyle = (
 
 export const addGameLabelSizeStyle = (
   _mounting = false,
-  square: boolean = false,
+  squares: boolean = false,
 ) => {
   let font_size = '0.7em';
-  if (square)
-    font_size = '0.8em';
+  if (squares)
+    font_size = '0.85em';
 
+  // TODO: Different font_sizes for library and home?
   addStyle(
     STYLE_GAME_LABEL_SIZE,
     `
-    .${appportraitClasses.LibraryItemBox} + div[id]
-    font-size: ${font_size};
+    .${gamepadLibraryClasses.GamepadLibrary} .${appportraitClasses.LibraryItemBox}.Panel + div[id] {
+      font-size: ${font_size};
+    }
+    .${appportraitClasses.InRecentGames}.${appportraitClasses.LibraryItemBox}.Panel + div[id] {
+      font-size: ${font_size};
+    }
     `,);
 };
 

--- a/src/patches/gameLabelsStyle.tsx
+++ b/src/patches/gameLabelsStyle.tsx
@@ -19,7 +19,16 @@ export const addGameLabelsStyle = (
   addStyle(
     STYLE_GAME_LABEL,
     `
-    .${appportraitClasses.LibraryItemBox} + div[id] {
+    .${gamepadLibraryClasses.GamepadLibrary} .${appportraitClasses.LibraryItemBox} + div[id] {
+      display: block !important;
+      text-align: center;
+      margin-top: 4px;
+      margin-bottom: 4px;
+      white-space: normal;
+      overflow: visible;
+      word-wrap: break-word;
+    }
+    .${appportraitClasses.LibraryItemBox}.Panel:not(:hover,:focus) + div[id] {
       display: block !important;
       text-align: center;
       margin-top: 4px;


### PR DESCRIPTION
One thing that always annoyed me in the library view was that it only showed the title images of the games, but not their names.  
This is especially annoying if you add non-steam games e.g. via Heroic and the image is not unique (and I don't bother to change it).  

This change adds an additional option to always show the game names below the capsule.   
The label unfortunately elements don't have a concrete class and have the inline property `display: none; `.  
Nevertheless, the selector `.${appportraitClasses.LibraryItemBox}.Panel + div[id]` is precise enough to find them.  

I have added them for both the library and the home view, but they could be separate options if needed.
In the home view where the recent games are shown, the game's name is actually shown when hovering/focusing it.

I have tested it on my steam deck.  
It works for both the normal and the square capsules.


The zip to install it can be found here: [SteamGridDB.zip](https://github.com/nkay08/decky-steamgriddb/releases/tag/v1.7.2-gameLabels)

Perhaps the fontsize, padding etc. could be further adjusted, but in my opinion this is good enough for now.

Some screenshots:

<img width="1920" height="1080" alt="20260604132757_1" src="https://github.com/user-attachments/assets/efb36a66-bbcd-4b82-a2d5-7d17014d9e6d" />
<img width="1920" height="1080" alt="20260604132749_1" src="https://github.com/user-attachments/assets/47b637e9-984f-4aa2-ae53-d1af2ec830c6" />
<img width="1920" height="1080" alt="20260604132732_1" src="https://github.com/user-attachments/assets/59a26a91-ec8c-4c1c-8004-633ce15542a8" />
