### PR TITLE
fix: icons not applying to official Steam games and stale current icon in Manage tab

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,12 @@ def get_steam_userdata():
 def get_steam_libcache():
     return get_steam_path() / 'appcache' / 'librarycache'
 
+def get_steam_icon_dir(appid):
+    return get_steam_libcache() / str(appid)
+
+def get_steam_icon_name(icon_hash):
+    return "%s.jpg" % icon_hash
+
 def get_userdata_config(steam32):
     return get_steam_userdata() / steam32 / 'config'
 
@@ -109,11 +115,31 @@ class Plugin:
                 return True
         raise Exception('Could not find shortcut to edit')
 
-    async def set_steam_icon_from_url(self, appid, url):
-        await self.download_file(url, get_steam_libcache(), file_name=("%s_icon.jpg" % appid))
+    async def set_steam_icon_from_url(self, appid, url, icon_hash):
+        # Poison the cache through a temp file, Steam restores the original icon
+        # if it catches its cache file being written to directly
+        output_dir = get_steam_icon_dir(appid)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        icon_name = get_steam_icon_name(icon_hash)
+        temp_path = output_dir / ("%s_temp" % icon_name)
+        if not await self.download_file(url, str(output_dir), file_name=temp_path.name):
+            temp_path.unlink(missing_ok=True)
+            raise Exception("Failed to download icon from %s" % url)
+        output_file = output_dir / icon_name
+        temp_path.replace(output_file)
+        return str(output_file)
 
-    async def set_steam_icon_from_path(self, appid, path):
-        copyfile(path, get_steam_libcache() / str("%s_icon.jpg" % appid))
+    async def set_steam_icon_from_path(self, appid, path, icon_hash):
+        # Poison the cache through a temp file, Steam restores the original icon
+        # if it catches its cache file being written to directly
+        output_dir = get_steam_icon_dir(appid)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        icon_name = get_steam_icon_name(icon_hash)
+        temp_path = output_dir / ("%s_temp" % icon_name)
+        copyfile(path, temp_path)
+        output_file = output_dir / icon_name
+        temp_path.replace(output_file)
+        return str(output_file)
 
     async def set_setting(self, key, value):
         self.settings.setSetting(key, value)

--- a/src/components/plugin-pages/ManageTab.tsx
+++ b/src/components/plugin-pages/ManageTab.tsx
@@ -27,7 +27,6 @@ const AssetBlock: FC<{
   const innerFocusRef = useRef<HTMLDivElement>(null);
   const refreshing = useRef(false);
 
-  // god is dead
   const refreshOverview = async () => {
     if (refreshing.current) return;
     refreshing.current = true;

--- a/src/components/plugin-pages/ManageTab.tsx
+++ b/src/components/plugin-pages/ManageTab.tsx
@@ -36,15 +36,8 @@ const AssetBlock: FC<{
     const appoverview = await getAppOverview(app.appid);
 
     if (assetType === 'icon' && appoverview?.icon_hash) {
-      // Today i choose violence
-      const hash = appoverview.icon_hash;
-      // fuck up the hash to force render the icon file from the cache
-      appoverview.icon_hash = String(new Date().getTime());
-      setOverview(appoverview);
-      // vibe for a bit
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      // now put that shit back
-      appoverview.icon_hash = hash;
+      // bump the icon url's cache buster so it gets read from disk again
+      appoverview.local_cache_version = Date.now();
     }
 
     setOverview(appoverview);
@@ -136,16 +129,9 @@ const LocalTab: FC = () => {
       const appoverview = await getAppOverview(appId);
       if (!appoverview) return;
 
-      // Today i choose violence
       if (appoverview.icon_hash) {
-        const hash = appoverview.icon_hash;
-        // fuck up the hash to force render the icon file from the cache
-        appoverview.icon_hash = String(new Date().getTime());
-        setOverview(appoverview);
-        // vibe for a bit
-        await new Promise((resolve) => setTimeout(resolve, 300));
-        // now put that shit back
-        appoverview.icon_hash = hash;
+        // bump the icon url's cache buster so it gets read from disk again
+        appoverview.local_cache_version = Date.now();
       }
 
       setOverview(appoverview);

--- a/src/hooks/useSGDB.tsx
+++ b/src/hooks/useSGDB.tsx
@@ -118,14 +118,16 @@ export const SGDBProvider: FC<{ children: ReactNode }> = ({ children }) => {
         );
         if (res !== 'icon_is_same_path') showRestartConfirm();
       } else {
-        if (appOverview) {
+        if (appOverview?.icon_hash) {
           // Redownload the icon from Steam
           await call<[
             appid: number | null,
             url: string,
+            icon_hash: string,
           ]>('set_steam_icon_from_url',
             appId,
-            window.appStore.GetIconURLForApp(appOverview)
+            window.appStore.GetIconURLForApp(appOverview),
+            appOverview.icon_hash
           );
         }
       }
@@ -227,12 +229,18 @@ export const SGDBProvider: FC<{ children: ReactNode }> = ({ children }) => {
         }
       } else {
         // Change default Steam icon by poisoning the cache like Boop does it
+        if (!appOverview?.icon_hash) {
+          throw new Error('Could not find the current icon hash for this app');
+        }
+
         const res = await call<[
           appid: number | null,
-          path: string | null,
+          location: string,
+          icon_hash: string,
         ], string | boolean>(path ? 'set_steam_icon_from_path' : 'set_steam_icon_from_url',
           appId,
-          url
+          url,
+          appOverview.icon_hash
         );
         log('set_steam_icon result', res);
       }


### PR DESCRIPTION
Fix icons not applying to official Steam games and stale current icon in Manage tab

- Steam reads icons from `librarycache/<appid>/<icon_hash>.jpg` now, so the old flat `librarycache/<appid>_icon.jpg` write went to a file nothing reads. Writing the new path has to go through a temp file and a rename as well, otherwise Steam catches its cache file being truncated mid-write and puts the original icon back. This approach is taken from how SGDBoop poisons the cache in `sgdboop.c`. The tradeoff is that the icon always has to be saved as .jpg no matter what the asset actually is since Steam builds the url as <icon_hash>.jpg and won't pick the file up under any other name. SGDBoop hardcodes the same extension for this reason.
- Updated the  Manage tab's current icon refresh by bumping `local_cache_version` which is the cache buster Steam puts in the icon url. This should be this should be a cleaner way of refreshing the cache instead of the previous hacky approach.

Tested on a Steam Deck (stable client) by changing the icon of an official Steam game from both a url and a local file path, checking the Manage tab updates to the new icon, and loading the game to confirm it shows there too. Clearing the asset puts the official icon back. Regression tested with non-Steam games to make sure shortcut icons still behave as before.

Fixes #131
