### PR TITLE
fix(ManageTab): show shortcut icons on first load

### DIFF
--- a/src/components/plugin-pages/ManageTab.tsx
+++ b/src/components/plugin-pages/ManageTab.tsx
@@ -51,6 +51,15 @@ const AssetBlock: FC<{
     refreshing.current = false;
   };
 
+  const isShortcutIcon = assetType === 'icon' && app.BIsShortcut();
+  const [isShortcutIconLoaded] = useState(() => Boolean(app.icon_data));
+
+  // Steam reads shortcut icon into icon_data as a result of this first render,
+  // so check again to pick up what just landed
+  useEffect(() => {
+    if (isShortcutIcon && !isShortcutIconLoaded) refreshOverview();
+  }, [isShortcutIcon, isShortcutIconLoaded]);
+
   const handleBrowse = async () => {
     const path = await openFilePicker(browseStartPath, true, undefined, {
       validFileExtensions: ['png','jpg','jpeg','gif','webp','apng','tiff','tga'],


### PR DESCRIPTION
Fixes an issue where the current icon for a shortcut icon (non-steam game) is blank on first load of the Manage tab. The user would normally need to exit and re-enter the Manage tab by navigating to another tab and back, or exiting the 'Change Artwork...' flow and re-entering it to trigger a refresh so the icon show up. 

**RCA**: Shortcuts have no `icon_hash` (only official steam games do which is why they don't encounter this issue), so their icon comes from `icon_data`, which Steam only fills in as a result of the first render that asks for it. `AssetBlock` holds the live overview object in state, and since that field is mutated in place, nothing re-renders when it lands so the icon stays blank until you leave the tab and come back.

**Fix**: records whether `icon_data` was already present during the first render, and if it wasn't, calls the existing `refreshOverview` once after mount. Shortcuts whose icon is already cached, Steam games, and the other asset types are unaffected.

**Test Plan**:
- `Change Artwork...` on a non-Steam game that has an icon configured.
- Open the Manage tab and verify the current icon on initial load, not a blank icon. 

Tested on a Steam Deck, stable client.
